### PR TITLE
Fix comment capitalization in AutoLockSpellbook.lua

### DIFF
--- a/AutoLockSpellbook.lua
+++ b/AutoLockSpellbook.lua
@@ -155,7 +155,7 @@ function AutoLock:SpellbookUpdatePlacement()
 
   if IsGeneralTabSelected() and SpellBookFrame:IsVisible() then
     local anchor = FindLastFreeSpellButton()
-		-- kein freier slot gefunden
+		-- kein freier Slot gefunden
 		if anchor == -1 then return end
     btn:ClearAllPoints()
     btn:SetPoint("CENTER", anchor, "CENTER", 0, 0)


### PR DESCRIPTION
Nach einer langen Review fällt auf, dass in Zeile 158 (AutoLockSpellbook.lua) "Slot" klein geschrieben wurde (umgangssprachlich kein Fehler). Jedoch wurde in Zeile 71 (AutoLockSpellbook.lua) "Slot" korrekt geschrieben. Daher bitten wir um Akzeptanz, dies sofort umgehend zu ändern. Danke!

LG - Jamie, Tamino