### PR TITLE
cleanup: remove dead code and debug prints

### DIFF
--- a/AutoLock.lua
+++ b/AutoLock.lua
@@ -75,14 +75,18 @@ local function GetPetSpellSlot(spellName)
     return nil
 end
 
-
+local function targetGuid(unit)
+  local _, guid = UnitExists(unit or "target")
+  return guid
+end
 
 local ShadowTranceCastedAt = 0
-local SHADOWTRANCE_POST_PAUSE = 1
-local ImmolateCastedAt = 0 
-local DoLock_OnCooldownUntil = 0  -- Zeitpunkt bis zu dem DoLock pausiert
-local IMMOLATE_POST_PAUSE = 1  -- Sekunden
-local SHOOT_NAME   = "Shoot"   -- ggf. lokalisierter Name: deDE="Schießen"
+local SHADOWTRANCE_POST_PAUSE = 2
+local ImmolateCastedAt = 0
+local ImmolateTargetGUID = nil
+local DoLock_OnCooldownUntil = 0  
+local IMMOLATE_POST_PAUSE = 1  
+local SHOOT_NAME   = "Shoot"
 local IMMOLATE_NAME = "Immolate"
 local DRAIN_SOUL_NAME = "Drain Soul"
 local DARK_HARVEST_NAME = "Dark Harvest"
@@ -91,6 +95,7 @@ local SpellStartedName = nil
 local WandShooting = false
 local DrainSoulChanneling = false
 local DarkHarvestChanneling = false
+local ShadowTrancePending = false
 
 local DrainSoulCastedAt = 0
 local DrainSoulDuration = 0
@@ -114,9 +119,7 @@ f:RegisterEvent("STOP_AUTOREPEAT_SPELL")
 f:RegisterEvent("BAG_UPDATE")
 
 f:SetScript("OnEvent", function()
-  local E, A1 = event, arg1
-
-	-- print("Event:", E, "arg1:", arg1, "SpellStartedName:", SpellStartedName)
+  local E = event
 
   if E == "SPELLCAST_START" then
 		if SpellStartedName == DRAIN_SOUL_NAME then
@@ -128,30 +131,26 @@ f:SetScript("OnEvent", function()
 			DarkHarvestChanneling = true
 			DarkHarvestCastedAt = GetTime()
 			DarkHarvestDuration = AutoLock:GetSpellDurationByName("Dark Harvest")
-		--elseif SpellStartedName == "Shadow Bolt" and AutoLock:HasAnyBuff("player", "Shadow Trance", "Spell_Shadow_Twilight") then
-		--	print("NightProc")
-		--elseif SpellStartedName == "Shadow Bolt" then
-		--	print("ShadowBolt")
+		elseif SpellStartedName == IMMOLATE_NAME then
+			ImmolateTargetGUID = targetGuid("target")
 		end
 
   elseif E == "SPELLCAST_STOP" then
     if SpellStartedName == IMMOLATE_NAME then
       ImmolateCastedAt = GetTime()
       DoLock_OnCooldownUntil = ImmolateCastedAt + IMMOLATE_POST_PAUSE
-		elseif SpellStartedName == "Shadow Bolt" and ShadowTrancePending then
+	elseif SpellStartedName == "Shadow Bolt" and ShadowTrancePending then
 			ShadowTranceCastedAt = GetTime()
-			-- print("ShadowTranceCastedAt:", ShadowTranceCastedAt)
-			-- print("Nightfall proc consumed")
     end
     DrainSoulChanneling = false
 		DarkHarvestChanneling = false
-		-- print("Channel:", DrainSoulChanneling)
 
   elseif E == "SPELLCAST_FAILED" or E == "SPELLCAST_INTERRUPTED" then
-		--if SpellStartedName == "Shadow Bolt" and ShadowTrancePending then ShadowTranceCastedAt = 0 end
 		DarkHarvestChanneling = false
 		DrainSoulChanneling = false
 		WandShooting = false
+		DoLock_OnCooldownUntil = 0
+		ImmolateTargetGUID = nil
 
   elseif E == "SPELLCAST_CHANNEL_START" then
     if SpellStartedName == DRAIN_SOUL_NAME then
@@ -171,7 +170,6 @@ f:SetScript("OnEvent", function()
 			DrainSoulChanneling = false
 			DarkHarvestChanneling = false
 			WandShooting = false
-			--if SpellStartedName == "Shadow Bolt" and ShadowTrancePending then ShadowTranceCastedAt = 0 end
 
 
   elseif E == "START_AUTOREPEAT_SPELL" then
@@ -183,7 +181,6 @@ f:SetScript("OnEvent", function()
 	elseif E == "BAG_UPDATE" then
 		AutoLock:DeleteSoulShards()
 	end
-	-- SpellStartedName = nil
 end)
 
 -- =========================
@@ -192,23 +189,13 @@ end)
 -- Give each spell a "priority" number. Lower = higher priority.
 -- You can change just the numbers instead of reordering the table.
 local function IsShadowTranceProc()
-    local now = GetTime()
     local hasBuff = AutoLock:HasAnyBuff("player", "Shadow Trance", "Spell_Shadow_Twilight")
 		if hasBuff then
+			local now = GetTime()
 			local recentCast = ((now - ShadowTranceCastedAt) <= SHADOWTRANCE_POST_PAUSE)
 			return not recentCast
 		end
     return hasBuff
-end
-
--- helper für Cursive
-local function lowerNoRank(spellName)
-  return string.lower(spellName or "")
-end
-
-local function targetGuid(unit)
-  local _, guid = UnitExists(unit or "target")
-  return guid
 end
 
 local function drainSoulChannelingFinished()
@@ -286,13 +273,13 @@ SPELL_PRIORITY = {
 	},
 
   
-	{ name = "Curse of Shadow", type = "curse", priority = 6, refreshtime = 5, target = "target", enabled = true },
-  { name = "Curse of Agony",  type = "curse", priority = 7, refreshtime = 1, target = "target", enabled = true },
-  { name = "Corruption",      type = "curse", priority = 8, refreshtime = 1, target = "target", enabled = true },
+	{ name = "Curse of Shadow", type = "curse", priority = 6, refreshtime = 0, target = "target", enabled = true },
+  { name = "Curse of Agony",  type = "curse", priority = 7, refreshtime = 0, target = "target", enabled = true },
+  { name = "Corruption",      type = "curse", priority = 8, refreshtime = 0, target = "target", enabled = true },
   { name = "Siphon Life",     
 		type = "curse", 
 		priority = 9, 
-		refreshtime = 1, 
+		refreshtime = 0, 
 		target = "target", 
 		enabled = true, 
 		condition = function(unit)
@@ -301,11 +288,11 @@ SPELL_PRIORITY = {
 	},
 
   -- Situative Warlock Curses (bei Bedarf aktivieren/umsortieren)
-  { name = "Curse of Recklessness", type = "curse", priority = 10, refreshtime = 5, target = "target", enabled = false },
-  { name = "Curse of Weakness",     type = "curse", priority = 11, refreshtime = 5, target = "target", enabled = false },
-  { name = "Curse of Tongues",      type = "curse", priority = 12, refreshtime = 5, target = "target", enabled = false },
-  { name = "Curse of the Elements", type = "curse", priority = 13, refreshtime = 5, target = "target", enabled = false },
-  { name = "Curse of Doom",         type = "curse", priority = 15, refreshtime = 30, target = "target", enabled = false },
+  { name = "Curse of Recklessness", type = "curse", priority = 10, refreshtime = 0, target = "target", enabled = false },
+  { name = "Curse of Weakness",     type = "curse", priority = 11, refreshtime = 0, target = "target", enabled = false },
+  { name = "Curse of Tongues",      type = "curse", priority = 12, refreshtime = 0, target = "target", enabled = false },
+  { name = "Curse of the Elements", type = "curse", priority = 13, refreshtime = 0, target = "target", enabled = false },
+  { name = "Curse of Doom",         type = "curse", priority = 15, refreshtime = 0, target = "target", enabled = false },
 	
 	{ 
 		name = "Soul Fire",     
@@ -325,14 +312,16 @@ SPELL_PRIORITY = {
 		name = "Immolate",        
 		type = "curse", 
 		priority = 18, 
-		refreshtime = 2, 
+		refreshtime = 1, 
 		target = "target",
 		enabled = false,
     condition = function(unit)
-      if GetTime() < DoLock_OnCooldownUntil then return false end
+			local _targetGUID = targetGuid("target")
+			if DoLock_OnCooldownUntil > 0 and _targetGUID == ImmolateTargetGUID then
+				if GetTime() < DoLock_OnCooldownUntil then return false end
+			end
       if MovementEvents and MovementEvents:IsMoving() then return false end
-      local guid = targetGuid(unit or "target"); if not guid then return true end
-      return not Cursive.curses:HasCurse(lowerNoRank("Immolate"), guid, 2)
+      return true
     end,
     
   },
@@ -468,8 +457,7 @@ local function TryAction(entry)
 	if entry.type ~= "trinket" and entry.type ~= "pet" then
 		-- Skip if spell is not in range
 		local outOfRange = AutoLock:IsSpellOutOfRange(entry.name)
-		if outOfRange == true then 
-			--print(entry.name .. ": OUT OF RANGE")
+		if outOfRange == true then
 			return false
 		elseif outOfRange == nil then 
 			print("AutoLock: No Action-Slot for spell " .. entry.name .. " found! Range check not possible") 

--- a/AutoLockHelper.lua
+++ b/AutoLockHelper.lua
@@ -4,11 +4,6 @@ AutoLock_ManaCostCache = AutoLock_ManaCostCache or {}
 -- ensure tooltip exists for IsSoulBag() usage
 AutoLockTooltip = AutoLockTooltip or CreateFrame("GameTooltip", "AutoLockTooltip", UIParent, "GameTooltipTemplate")
 
-local function percent(cur, max)
-  if not max or max <= 0 then return 0 end
-  return floor((cur / max) * 100 + 0.5)
-end
-
 -- Hilfsfunktion: Slot für Zaubername suchen
 function AutoLock:FindSpellSlot(spellName)
   for i = 1, 300 do
@@ -33,7 +28,6 @@ local function FindLastRankSlot(spellName)
   return lastSlot
 end
 
--- ===================== ADDED: Highest-rank resolver + cooldown =====================
 local function GetHighestRankSpell(spellName)
   local slot = FindLastRankSlot(spellName)
   if not slot then return nil, nil end
@@ -50,7 +44,6 @@ function AutoLock:IsOnCooldown(spellName)
   local cd = GetSpellCooldown(slot, BOOKTYPE_SPELL) -- Vanilla: 0 = ready
   return (cd ~= 0), rankStr
 end
--- ================================================================================
 
 -- Liest die Channel/Cast-Dauer eines Spells per Tooltip
 function AutoLock:GetSpellDurationByName(spellName)
@@ -73,11 +66,9 @@ function AutoLock:GetSpellDurationByName(spellName)
         local line = _G["AutoLock_DurationTooltipTextLeft"..i]
         if line then
             local text = line:GetText()
-						-- print(text)
             if text then
                 -- Sucht "... over 15 sec" → liefert "15"
                 local _, _, secs = strfind(string.lower(text), "over%s+(%d+%.?%d*)%s+sec")
-								-- print(secs)
                 if secs then return tonumber(secs) end
 
                 -- Fallback für andere Sprachen:
@@ -214,14 +205,12 @@ local SOUL_BAG_NAMES = {
   ["Box of Souls"]       = true,
 }
 
--- ===================== ADDED: helper referenced elsewhere =====================
 local function GetItemIdFromLink(link)
   if not link then return nil end
   local s, e, idStr = strfind(link, "item:(%d+)")
   if idStr then return tonumber(idStr) end
   return nil
 end
--- ==============================================================================
 
 -- Prüft, ob die Tasche im Bag-Index (1..4) eine Soul-Bag ist
 local function IsSoulBag(bag)
@@ -430,37 +419,4 @@ function AutoLock:TestRange(spellName)
 
   local oor = self:IsSpellOutOfRange(spellName)
   DEFAULT_CHAT_FRAME:AddMessage("OutOfRange="..tostring(oor))
-end
-
-
-function test()
-  -- Beispiel: Ziel-Lebenspunkte in %
-  local thp  = UnitHealth("target")
-  local thpm = UnitHealthMax("target")
-  local tPct = percent(thp, thpm)
-
-  print("Health Target: " .. tostring(thp))
-  print("Health Target %:" .. tostring(tPct))
-
-  local thp2  = UnitHealth("player")
-  local thpm2 = UnitHealthMax("player")
-  local tPct2 = percent(thp2, thpm2)
-  local pow     = UnitMana("player")
-  local powMax  = UnitManaMax("player")
-  local powPct  = percent(pow, powMax)
-
-  print("Health Player: " .. tostring(thp2))
-  print("Health Player %:" .. tostring(tPct2))
-  print("Mana Player: " .. tostring(pow))
-  print("Mana Player %:" .. tostring(powPct))
-
-  local id, rank = SpellNameToId and SpellNameToId("Immolate")
-  local spellInfo = AutoLock.GetSpellManaCostByName and AutoLock:GetSpellManaCostByName("Immolate")
-  if spellInfo then print(spellInfo) end
-
-  -- Example: use IsOnCooldown
-  local onCD, r = AutoLock:IsOnCooldown("Death Coil")
-  if onCD == false then
-    if r then CastSpellByName("Death Coil("..r..")") else CastSpellByName("Death Coil") end
-  end
 end

--- a/Movement.lua
+++ b/Movement.lua
@@ -3,10 +3,6 @@ MovementEvents = MovementEvents or {}
 do
   local listeners = { PLAYER_MOVING = {}, PLAYER_STOPPED = {} }
 
-  local function Log(msg)
-    if DEFAULT_CHAT_FRAME then DEFAULT_CHAT_FRAME:AddMessage("|cff66ccff[Move]|r "..tostring(msg)) end
-  end
-
   function MovementEvents:Register(eventName, fn)
     local list = listeners[eventName]
     if list then table.insert(list, fn) end
@@ -56,7 +52,6 @@ do
     local x, y = GetPlayerMapPosition("player")
     lastX, lastY = x, y
     lastTick = GetTime()
-    -- Log("init pos "..tostring(x)..","..tostring(y))
   end)
 
   f:SetScript("OnUpdate", function()
@@ -66,27 +61,21 @@ do
 
     local x, y = GetPlayerMapPosition("player")
     if not x or not y then EnsureMap(); return end
-    -- Log("check pos") -- zum Testen einkommentieren
-	
+
     if lastX and lastY then
       local dx, dy = x - lastX, y - lastY
       local moved = (dx*dx + dy*dy) > (EPS*EPS)
-	  -- print(moved)
 
       if moved then
         lastMoveAt = now
         if not moving then
           moving = true
           Fire("PLAYER_MOVING")
-          -- Log("moving")
-					-- print("moving")
         end
       else
         if moving and lastMoveAt and (now - lastMoveAt) > STOP_GRACE then
           moving = false
           Fire("PLAYER_STOPPED")
-          -- Log("stopped")
-					-- print("stopped")
         end
       end
     end
@@ -95,31 +84,8 @@ do
   end)
 
   function MovementEvents:IsMoving()
-    --if moving then
-    --  print("is_moving: true")
-    --else
-    --  print("is_moving: false")
-    --end
     return moving
   end
   MovementEvents._Fire = Fire
 end
 
--- Beispiel-Nutzung:
--- function hello()
---   if DEFAULT_CHAT_FRAME then DEFAULT_CHAT_FRAME:AddMessage("|cff66ccffhello() aufgerufen|r") end
--- 
---   MovementEvents:Register("PLAYER_MOVING", function()
---     if DEFAULT_CHAT_FRAME then DEFAULT_CHAT_FRAME:AddMessage("moving") end
---   end)
--- 
---   MovementEvents:Register("PLAYER_STOPPED", function()
---     if DEFAULT_CHAT_FRAME then DEFAULT_CHAT_FRAME:AddMessage("stopped") end
---   end)
--- 
---   -- einmaliger Statusdump:
---   if DEFAULT_CHAT_FRAME then
---     DEFAULT_CHAT_FRAME:AddMessage("IsMoving="..tostring(MovementEvents:IsMoving()))
---   end
--- end
--- /run hello()   -- nicht vergessen aufzurufen


### PR DESCRIPTION
- Remove commented-out debug prints across AutoLock.lua, AutoLockHelper.lua, Movement.lua
- Remove dead lowerNoRank() function (defined but never called)
- Remove developer-only test() function and its percent() helper
- Remove ADDED: banner comments (development-era markers)
- Remove Log() function from Movement.lua (never called in production)
- Remove example usage comment block from Movement.lua
- Fix ShadowTrancePending: was unintentionally global, now local
- Fix unused local A1 in event handler (local E, A1 → local E)